### PR TITLE
Fix for under -std=c99 version style (comile error fix)

### DIFF
--- a/fa_regexp_class.c
+++ b/fa_regexp_class.c
@@ -205,12 +205,14 @@ fa_regexp_class_t *fa_regexp_class_named(char *name) {
 fa_regexp_class_t *fa_regexp_class_range(int *pairs, int pairs_n) {
   fa_regexp_class_t *rc;
   fa_regexp_class_chars_t *rcc;
+  int i;
+  int j;
 
   rc = fa_regexp_class_create();
   rcc = fa_regexp_class_chars_create();
-
-  for (int i = 0; i < pairs_n; i++) {
-    for (int j = pairs[i*2]; j <= pairs[i*2+1]; j++)
+  
+  for (i = 0; i < pairs_n; i++) {
+    for (j = pairs[i*2]; j <= pairs[i*2+1]; j++)
       BITFIELD_SET(rcc->map, j);
   }
 

--- a/faexample.c
+++ b/faexample.c
@@ -21,7 +21,8 @@
 static void *state_pri(void **opaques, int opaques_n) {
   // prioritized lowest number
   void *opaque = opaques[0];
-  for (int i = 1; i < opaques_n; i++) {
+  int i;
+  for (i = 1; i < opaques_n; i++) {
     if ((intptr_t)opaques[i] < (intptr_t)opaque)
       opaque = opaques[i];
   }

--- a/faexample.c
+++ b/faexample.c
@@ -43,31 +43,42 @@ int main(int argc, char **argv) {
   fa_init();
 
   // create union NFA of two regexp NFAs
-  // (1) fa_t *a_fa = fa_regexp_fa("^(a|b)*ab(a|b)*|(a|b)*a|b*$", &errstr, &errpos, NULL);
-  // (2) fa_t *a_fa = fa_regexp_fa("^(a|b)*(ab|ba)(a|b)*|a*|b*$", &errstr, &errpos, NULL);
-  fa_t *a_fa = fa_regexp_fa("^(_|[a-zA-Z])(_|[a-zA-Z]|[0-9])*$", &errstr, &errpos, NULL);
-
-
+  fa_t *a_fa = fa_regexp_fa("^aa*$", &errstr, &errpos, NULL);
   // assign 0 to all accepting states for first regexp
   fa_set_accepting_opaque(a_fa, (void *)0);
-  // fa_t *b_fa = fa_regexp_fa("^a(a|b)$", &errstr, &errpos, NULL);
+  fa_t *b_fa = fa_regexp_fa("^a(a|b)$", &errstr, &errpos, NULL);
   // assign 1 to all accepting states for second regexp
-  // fa_set_accepting_opaque(b_fa, (void *)1);
-  // fa_t *union_fa = fa_union(a_fa, b_fa);
-  fa_graphviz_output(a_fa, "pics/nfa.dot", NULL);
+  fa_set_accepting_opaque(b_fa, (void *)1);
+  fa_t *union_fa = fa_union(a_fa, b_fa);
+  fa_graphviz_output(union_fa, "union.dot", NULL);
 
   // determinize and choose lowest opaque number when more than one opaque
   // value end up in same accepting state.
   // this happens when two regexps are overlapping.
-  fa_t *dfa = fa_determinize_ex(a_fa, state_pri, NULL, NULL);
-  fa_graphviz_output(dfa, "pics/dfa.dot", NULL);
+  fa_t *dfa = fa_determinize_ex(union_fa, state_pri, NULL, NULL);
+  fa_graphviz_output(dfa, "dfa.dot", NULL);
 
   // minimize and treat states with different opaque values as distinguishable.
   // this is to be able to know which original regexp has a match when using
   // the minimize DFA
   fa_t *mdfa = fa_minimize_ex(dfa, state_cmp, NULL);
   fa_destroy(dfa);
-  fa_graphviz_output(mdfa, "pics/mdfa.dot", NULL);
+  fa_graphviz_output(mdfa, "mdfa.dot", NULL);
+
+  // convert minimal DFA into format suitable for running it on input
+  fa_sim_t *sim = fa_sim_create(mdfa);
+  fa_destroy(mdfa);
+
+  fa_sim_run_t fsr;
+
+  fa_sim_run_init(sim, &fsr);
+  if (fa_sim_run(sim, &fsr, (uint8_t *)"aa", 2) == FA_SIM_RUN_ACCEPT)
+    printf("matches %p\n", fsr.opaque); // outputs matches 0x0
+  fa_sim_run_init(sim, &fsr);
+  if (fa_sim_run(sim, &fsr, (uint8_t *)"ab", 2) == FA_SIM_RUN_ACCEPT)
+    printf("matches %p\n", fsr.opaque); // outputs matches 0x1
+
+  fa_sim_destroy(sim);
 
   return 0;
 }

--- a/faexample.c
+++ b/faexample.c
@@ -43,42 +43,31 @@ int main(int argc, char **argv) {
   fa_init();
 
   // create union NFA of two regexp NFAs
-  fa_t *a_fa = fa_regexp_fa("^aa*$", &errstr, &errpos, NULL);
+  // (1) fa_t *a_fa = fa_regexp_fa("^(a|b)*ab(a|b)*|(a|b)*a|b*$", &errstr, &errpos, NULL);
+  // (2) fa_t *a_fa = fa_regexp_fa("^(a|b)*(ab|ba)(a|b)*|a*|b*$", &errstr, &errpos, NULL);
+  fa_t *a_fa = fa_regexp_fa("^(_|[a-zA-Z])(_|[a-zA-Z]|[0-9])*$", &errstr, &errpos, NULL);
+
+
   // assign 0 to all accepting states for first regexp
   fa_set_accepting_opaque(a_fa, (void *)0);
-  fa_t *b_fa = fa_regexp_fa("^a(a|b)$", &errstr, &errpos, NULL);
+  // fa_t *b_fa = fa_regexp_fa("^a(a|b)$", &errstr, &errpos, NULL);
   // assign 1 to all accepting states for second regexp
-  fa_set_accepting_opaque(b_fa, (void *)1);
-  fa_t *union_fa = fa_union(a_fa, b_fa);
-  fa_graphviz_output(union_fa, "union.dot", NULL);
+  // fa_set_accepting_opaque(b_fa, (void *)1);
+  // fa_t *union_fa = fa_union(a_fa, b_fa);
+  fa_graphviz_output(a_fa, "pics/nfa.dot", NULL);
 
   // determinize and choose lowest opaque number when more than one opaque
   // value end up in same accepting state.
   // this happens when two regexps are overlapping.
-  fa_t *dfa = fa_determinize_ex(union_fa, state_pri, NULL, NULL);
-  fa_graphviz_output(dfa, "dfa.dot", NULL);
+  fa_t *dfa = fa_determinize_ex(a_fa, state_pri, NULL, NULL);
+  fa_graphviz_output(dfa, "pics/dfa.dot", NULL);
 
   // minimize and treat states with different opaque values as distinguishable.
   // this is to be able to know which original regexp has a match when using
   // the minimize DFA
   fa_t *mdfa = fa_minimize_ex(dfa, state_cmp, NULL);
   fa_destroy(dfa);
-  fa_graphviz_output(mdfa, "mdfa.dot", NULL);
-
-  // convert minimal DFA into format suitable for running it on input
-  fa_sim_t *sim = fa_sim_create(mdfa);
-  fa_destroy(mdfa);
-
-  fa_sim_run_t fsr;
-
-  fa_sim_run_init(sim, &fsr);
-  if (fa_sim_run(sim, &fsr, (uint8_t *)"aa", 2) == FA_SIM_RUN_ACCEPT)
-    printf("matches %p\n", fsr.opaque); // outputs matches 0x0
-  fa_sim_run_init(sim, &fsr);
-  if (fa_sim_run(sim, &fsr, (uint8_t *)"ab", 2) == FA_SIM_RUN_ACCEPT)
-    printf("matches %p\n", fsr.opaque); // outputs matches 0x1
-
-  fa_sim_destroy(sim);
+  fa_graphviz_output(mdfa, "pics/mdfa.dot", NULL);
 
   return 0;
 }


### PR DESCRIPTION
Hi! 
Just tried your project to create simple transitions between regex => nfa => dfa.
Found some problems with running Makefile, so want to provide some extra info for future users.

Two points:
1. To my mind 'bison' should be added in dependencies
2. Counter initialization in for-loop scope will cause problems without -std=c99

Hope it wil be useful!
